### PR TITLE
Improve testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
+dist: xenial
+
 language: python
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8-dev"
+
 matrix:
-    include:
-        -   env: TOXENV=py36
-            python: 3.6
-install: pip install tox
+    allow_failures:
+        - python: "3.8-dev"
+
+install: pip install tox-travis
 script: tox
 cache:
     directories:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-coverage
 pre-commit
 pytest
+pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py36
+envlist = py3{6,7,8}
+skip_missing_interpreters = true
 
 [testenv]
 deps = -rrequirements-dev.txt
 commands =
-    coverage erase
-    coverage run -m pytest {posargs:tests}
-    coverage report --fail-under 100
+    pytest {posargs:tests} --cov --cov-fail-under 100
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 


### PR DESCRIPTION
Hello,

First of all, thank you for the great tool!

As a software engineer, I'd like to see tests for all supported versions of `Python` on `CI`.

These changes:
 - Add Python `3.7` and `3.8-dev` to `.travis.yml`
 - Add `py37` and `py38` to the `envlist` at `tox.ini`
 - Introduce [pytest-cov](https://github.com/pytest-dev/pytest-cov) and [tox-travis](https://github.com/tox-dev/tox-travis)
 - Replace `coverage` with `pytest --cov` at `tox.ini`