### PR TITLE
allow exclusion of symbols using regex

### DIFF
--- a/dead.py
+++ b/dead.py
@@ -287,6 +287,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         help='regex for file exclusion, default %(default)r',
     )
     parser.add_argument(
+        '--exclude-symbol', default='^$',
+        help='regex for symbol exclusion, default %(default)r',
+    )
+    parser.add_argument(
         '--tests', default='(^|/)(tests?|testing)/',
         help='regex to mark files as tests, default %(default)r',
     )
@@ -309,6 +313,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     files_re = re.compile(args.files)
     exclude_re = re.compile(args.exclude)
+    exclude_symbol_re = re.compile(args.exclude_symbol)
     tests_re = re.compile(args.tests)
     for filename, is_test in _filenames(files_re, exclude_re, tests_re):
         tree = _ast(filename)
@@ -337,6 +342,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 pass  # ignore conventional cls / self
             elif k not in scope.reads and not v:
                 pass  # all references disabled
+            elif exclude_symbol_re.match(k):
+                pass  # symbol matches symbols to ignore
             elif k not in scope.reads and k not in scope.reads_tests:
                 print(f'{k} is never read, defined in {", ".join(sorted(v))}')
                 retv = 1

--- a/tests/dead_test.py
+++ b/tests/dead_test.py
@@ -308,7 +308,7 @@ def test_regex_ignore_symbol(git_dir, capsys):
     out, _ = capsys.readouterr()
     assert out == '_x is never read, defined in f.py:1\n'
     # now same with ignore symbol regex
-    assert not dead.main(("--exclude-symbol", "^_*"))
+    assert not dead.main(('--exclude-symbol', '^_*'))
 
 
 def test_unused_argument_ignore_symbol(git_dir, capsys):
@@ -323,7 +323,8 @@ def test_unused_argument_ignore_symbol(git_dir, capsys):
         '_d is never read, defined in f.py:1\n'
     )
     # now same with ignore symbol regex
-    assert not dead.main(("--exclude-symbol", "^_*"))
+    assert not dead.main(('--exclude-symbol', '^_*'))
+
 
 @pytest.mark.xfail(sys.version_info < (3, 8), reason='py38+')
 def test_unused_positional_only_argument(git_dir, capsys):  # pragma: no cover
@@ -336,4 +337,3 @@ def test_unused_positional_only_argument(git_dir, capsys):  # pragma: no cover
     assert dead.main(())
     out, _ = capsys.readouterr()
     assert out == 'unused is never read, defined in f.py:1\n'
-


### PR DESCRIPTION
additional commandline argument `--exclude-symbol` to exclude "dead" symbols/arguments matching a given pattern, this can be an alternative to placing a lot of `#dead: disable` into your code

example:
`dead --exclude-symbol "^_.*"` 

to ignore all "dead" symbols starting with an unserscore