### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:
@@ -32,7 +32,7 @@ repos:
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [py36, py37]
+    toxenvs: [py37, py38, py39, py310]
     os: linux

--- a/dead.py
+++ b/dead.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import ast
 import collections
@@ -9,13 +11,10 @@ import subprocess
 import tokenize
 from typing import DefaultDict
 from typing import Generator
-from typing import List
 from typing import NewType
-from typing import Optional
 from typing import Pattern
 from typing import Sequence
 from typing import Set
-from typing import Tuple
 from typing import Union
 
 from identify.identify import tags_from_path
@@ -50,9 +49,9 @@ class Visitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.filename = ''
         self.is_test = False
-        self.previous_scopes: List[Scope] = []
+        self.previous_scopes: list[Scope] = []
         self.scopes = [Scope()]
-        self.disabled: Set[FileLine] = set()
+        self.disabled: set[FileLine] = set()
 
     @contextlib.contextmanager
     def file_ctx(
@@ -192,7 +191,7 @@ class Visitor(ast.NodeVisitor):
         line = line.split(':', 1)[1].strip()
         func_match = TYPE_FUNC_RE.match(line)
         if not func_match:
-            parts: Tuple[str, ...] = (line,)
+            parts: tuple[str, ...] = (line,)
         else:
             parts = (
                 func_match.group(1).replace('*', ''),
@@ -213,7 +212,7 @@ def _filenames(
         files_re: Pattern[str],
         exclude_re: Pattern[str],
         tests_re: Pattern[str],
-) -> Generator[Tuple[str, bool], None, None]:
+) -> Generator[tuple[str, bool], None, None]:
     # TODO: zsplit is more correct than splitlines
     out = subprocess.check_output(('git', 'ls-files')).decode()
     for filename in out.splitlines():
@@ -276,7 +275,7 @@ def parse_entry_points_setup_cfg(visitor: Visitor) -> None:
                     visitor.read(match.group(1), node)
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--files', default='',

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
@@ -21,7 +20,7 @@ classifiers =
 py_modules = dead
 install_requires =
     identify
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/dead_test.py
+++ b/tests/dead_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 import sys
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,pre-commit
+envlist = py37,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos